### PR TITLE
fix(issue-1): error handling for empty runs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_synthetic_state"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["andy baizon <andrew.baizon@oneadvanced.com>"]
 description = "lambda function to return aws synthetic canary status"

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,18 @@ async fn check_canary (_event: LambdaEvent<Value>) -> Result<(), Error> {
         .send()
         .await?;
 
-    // parse the canary run to get the raw status as a string
+    // parse the canary runs into a vec
     let canary_run = canary_runs.canaries_last_run().unwrap();
-    let run = &canary_run.to_vec()[0];
+    let run_vec = &canary_run.to_vec();
+
+    // handle 'No Run Data'
+    if run_vec.is_empty() {
+        let err = String::from("CanaryFailed-NoRunData").into();
+        return Err(err);
+    }
+
+    // handle a successful run
+    let run = &run_vec[0];
     let state = run
         .last_run()
         .unwrap()


### PR DESCRIPTION
run parsing split into 2 distinct sections, checking for empty runs befor parsing

Closes #1
